### PR TITLE
Fixing audio in Emscripten builds

### DIFF
--- a/3rdparty/zaudio/build.zig
+++ b/3rdparty/zaudio/build.zig
@@ -37,18 +37,18 @@ pub fn build(b: *std.Build) void {
 
     miniaudio.addCSourceFile(.{
         .file = b.path("src/zaudio.c"),
-        .flags = &.{"-std=c99"},
+        .flags = &.{if (target.result.isWasm()) "-std=gnu99" else "-std=c99"}, // DELVE FRAMEWORK EDIT: Need gnu99 for web audio
     });
     miniaudio.addCSourceFile(.{
         .file = b.path("libs/miniaudio/miniaudio.c"),
         .flags = &.{
-            "-DMA_NO_WEBAUDIO",
+            // "-DMA_NO_WEBAUDIO", // DELVE FRAMEWORK EDIT: We want web audio!
             "-DMA_NO_ENCODING",
             "-DMA_NO_NULL",
             "-DMA_NO_JACK",
             "-DMA_NO_DSOUND",
             "-DMA_NO_WINMM",
-            "-std=c99",
+            if (target.result.isWasm()) "-std=gnu99" else "-std=c99", // DELVE FRAMEWORK EDIT: Need gnu99 for web audio
             "-fno-sanitize=undefined",
             if (target.result.os.tag == .macos) "-DMA_NO_RUNTIME_LINKING" else "",
         },

--- a/src/examples/stresstest.zig
+++ b/src/examples/stresstest.zig
@@ -37,5 +37,5 @@ pub fn main() !void {
     // try animation_example.registerModule();
     // try forest_example.registerModule();
 
-    try app.start(app.AppConfig{ .title = "Delve Framework - Stress Test" });
+    try app.start(app.AppConfig{ .title = "Delve Framework - Stress Test", .enable_audio = true });
 }


### PR DESCRIPTION
Zaudio doesn't support Emscripten just yet, although it is super close to doing so. These build.zig changes in Zaudio get that working.